### PR TITLE
v0.2: updating to accomodate qpixg4 v2.0.0

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,3 +1,3 @@
-geant4 10.6.0
+geant4 11.0.0
 ROOT 6.18/04
 python 3.7.5

--- a/packages.txt
+++ b/packages.txt
@@ -1,6 +1,6 @@
 marley v1.2.0 git@github.com:MARLEY-MC/marley.git
-qpixg4 v1.2.0 git@github.com:q-pix/qpixg4.git
-qpixrtd v1.1.0 git@github.com:q-pix/qpixrtd.git
-qpixar v0.2.0 git@github.com:q-pix/qpixar.git
+qpixg4 v2.0.0 git@github.com:Q-Pix/qpixg4.git
+qpixrtd v1.1.0 git@github.com:Q-Pix/qpixrtd.git
+qpixar v0.2.0 git@github.com:Q-Pix/qpixar.git
 
 


### PR DESCRIPTION
Updated packages to include qpixg4 v2.0.0.
Updated dependencies to require minimum of Geant4 version 11